### PR TITLE
Add cultivator recipe and output

### DIFF
--- a/src/main/java/com/peeko32213/unusualprehistory/common/recipe/CultivatorRecipe.java
+++ b/src/main/java/com/peeko32213/unusualprehistory/common/recipe/CultivatorRecipe.java
@@ -1,0 +1,141 @@
+package com.peeko32213.unusualprehistory.common.recipe;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.peeko32213.unusualprehistory.UnusualPrehistory;
+import net.minecraft.core.NonNullList;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraft.world.item.crafting.ShapedRecipe;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.LootTable;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.server.ServerLifecycleHooks;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class CultivatorRecipe implements Recipe<SimpleContainer> {
+    private final ResourceLocation id;
+    private final ItemStack output;
+    private final NonNullList<Ingredient> recipeItems;
+
+    public CultivatorRecipe(ResourceLocation id, ItemStack output,
+                            NonNullList<Ingredient> recipeItems) {
+        this.id = id;
+        this.output = output;
+        this.recipeItems = recipeItems;
+    }
+
+    @Override
+    public boolean matches(SimpleContainer pContainer, Level pLevel) {
+        return recipeItems.get(0).test(pContainer.getItem(0));
+    }
+
+    @Override
+    public ItemStack assemble(SimpleContainer pContainer) {
+        return output.copy();
+    }
+
+    @Override
+    public boolean canCraftInDimensions(int pWidth, int pHeight) {
+        return true;
+    }
+
+    @Override
+    public ItemStack getResultItem() {
+        return output;
+    }
+
+    @Override
+    public ResourceLocation getId() {
+        return id;
+    }
+
+    @Override
+    public RecipeSerializer<?> getSerializer() {
+        return Serializer.INSTANCE;
+    }
+
+    @Override
+    public RecipeType<?> getType() {
+        return Type.INSTANCE;
+    }
+
+    public static class Type implements RecipeType<CultivatorRecipe> {
+        private Type() { }
+        public static final Type INSTANCE = new Type();
+    }
+
+    public static class Serializer implements RecipeSerializer<CultivatorRecipe> {
+        public static final Serializer INSTANCE = new Serializer();
+        public static final ResourceLocation ID = new ResourceLocation(UnusualPrehistory.MODID,"cultivator");
+
+        @Override
+        public CultivatorRecipe fromJson(ResourceLocation id, JsonObject json) {
+            ItemStack output = ShapedRecipe.itemStackFromJson(GsonHelper.getAsJsonObject(json, "output"));
+            JsonArray ingredients = GsonHelper.getAsJsonArray(json, "ingredients");
+            NonNullList<Ingredient> inputs = NonNullList.withSize(1, Ingredient.EMPTY);
+
+            for (int i = 0; i < inputs.size(); i++) {
+                inputs.set(i, Ingredient.fromJson(ingredients.get(i)));
+            }
+
+            return new CultivatorRecipe(id, output, inputs);
+        }
+
+        @Override
+        public CultivatorRecipe fromNetwork(ResourceLocation id, FriendlyByteBuf buf) {
+            NonNullList<Ingredient> inputs = NonNullList.withSize(buf.readInt(), Ingredient.EMPTY);
+
+            for (int i = 0; i < inputs.size(); i++) {
+                inputs.set(i, Ingredient.fromNetwork(buf));
+            }
+
+            ItemStack output = buf.readItem();
+            return new CultivatorRecipe(id, output, inputs);
+        }
+
+        @Override
+        public void toNetwork(FriendlyByteBuf buf, CultivatorRecipe recipe) {
+            buf.writeInt(recipe.getIngredients().size());
+            for (Ingredient ing : recipe.getIngredients()) {
+                ing.toNetwork(buf);
+            }
+            buf.writeItemStack(recipe.output, false);
+        }
+
+        @Override
+        public RecipeSerializer<?> setRegistryName(ResourceLocation name) {
+            return INSTANCE;
+        }
+
+        @Nullable
+        @Override
+        public ResourceLocation getRegistryName() {
+            return ID;
+        }
+
+        @Override
+        public Class<RecipeSerializer<?>> getRegistryType() {
+            return Serializer.castClass(RecipeSerializer.class);
+        }
+
+        @SuppressWarnings("unchecked") // Need this wrapper, because generics
+        private static <G> Class<G> castClass(Class<?> cls) {
+            return (Class<G>)cls;
+        }
+    }
+}

--- a/src/main/java/com/peeko32213/unusualprehistory/common/screen/CultivatorMenu.java
+++ b/src/main/java/com/peeko32213/unusualprehistory/common/screen/CultivatorMenu.java
@@ -25,13 +25,13 @@ public class CultivatorMenu extends AbstractContainerMenu {
     private final ContainerData data;
 
     public CultivatorMenu(int pContainerId, Inventory inv, FriendlyByteBuf extraData) {
-        this(pContainerId, inv, inv.player.level.getBlockEntity(extraData.readBlockPos()), new SimpleContainerData(3));
+        this(pContainerId, inv, inv.player.level.getBlockEntity(extraData.readBlockPos()), new SimpleContainerData(4));
     }
 
 
     public CultivatorMenu(int pContainerId, Inventory inv, BlockEntity entity, ContainerData data) {
         super(UPMenuTypes.CULTIVATOR_MENU.get(), pContainerId);
-        checkContainerSize(inv, 3);
+        checkContainerSize(inv, 4);
         blockEntity = ((CultivatorBlockEntity) entity);
         this.level = inv.player.level;
         this.data = data;
@@ -44,6 +44,7 @@ public class CultivatorMenu extends AbstractContainerMenu {
             this.addSlot(new SlotItemHandler(handler, 1, 80, 64));
 
             this.addSlot(new UPResultSlot(handler, 2, 128, 31));
+            this.addSlot(new UPResultSlot(handler, 3, 152, 64));
 
 
         });
@@ -66,13 +67,12 @@ public class CultivatorMenu extends AbstractContainerMenu {
     }
 
     public int getScaledFuel(int scale) {
-        // TODO save and load fuel from data
-        int progress = this.data.get(0);
-        int maxProgress = this.data.get(1);
-        if(progress == 0 || maxProgress == 0) {
+        int fuel = this.data.get(2);
+        int maxFuel = this.data.get(3);
+        if(fuel == 0 || maxFuel == 0) {
             return 0;
         }
-        return Mth.ceil((float) scale * (float) progress / (float) maxProgress);
+        return Mth.ceil((float) scale * (float) fuel / (float) maxFuel);
     }
 
     private static final int HOTBAR_SLOT_COUNT = 9;
@@ -84,7 +84,7 @@ public class CultivatorMenu extends AbstractContainerMenu {
     private static final int TE_INVENTORY_FIRST_SLOT_INDEX = VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT;
 
     // THIS YOU HAVE TO DEFINE!
-    private static final int TE_INVENTORY_SLOT_COUNT = 3;  // must be the number of slots you have!
+    private static final int TE_INVENTORY_SLOT_COUNT = 4;  // must be the number of slots you have!
 
     @Override
     public ItemStack quickMoveStack(Player playerIn, int index) {

--- a/src/main/java/com/peeko32213/unusualprehistory/core/registry/UPRecipes.java
+++ b/src/main/java/com/peeko32213/unusualprehistory/core/registry/UPRecipes.java
@@ -2,6 +2,7 @@ package com.peeko32213.unusualprehistory.core.registry;
 
 import com.peeko32213.unusualprehistory.UnusualPrehistory;
 import com.peeko32213.unusualprehistory.common.recipe.AnalyzerRecipe;
+import com.peeko32213.unusualprehistory.common.recipe.CultivatorRecipe;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.registries.DeferredRegister;
@@ -15,6 +16,9 @@ public class UPRecipes {
 
     public static final RegistryObject<RecipeSerializer<AnalyzerRecipe>> ANALYZER_SERIALIZER =
             SERIALIZERS.register("analyzing", () -> AnalyzerRecipe.Serializer.INSTANCE);
+
+    public static final RegistryObject<RecipeSerializer<CultivatorRecipe>> CULTIVATOR_SERIALIZER =
+            SERIALIZERS.register("cultivator", () -> CultivatorRecipe.Serializer.INSTANCE);
 
     public static void register(IEventBus eventBus) {
         SERIALIZERS.register(eventBus);

--- a/src/main/resources/data/unusualprehistory/recipes/ammon_eggs_from_cultivator.json
+++ b/src/main/resources/data/unusualprehistory/recipes/ammon_eggs_from_cultivator.json
@@ -1,0 +1,11 @@
+{
+  "type": "unusualprehistory:cultivator",
+  "ingredients": [
+    {
+      "item": "unusualprehistory:ammonite_flask"
+    }
+  ],
+  "output": {
+    "item": "unusualprehistory:ammon_eggs"
+  }
+}

--- a/src/main/resources/data/unusualprehistory/tags/items/filled_flasks.json
+++ b/src/main/resources/data/unusualprehistory/tags/items/filled_flasks.json
@@ -1,0 +1,12 @@
+{
+  "replace": false,
+  "values": [
+    "unusualprehistory:ammonite_flask",
+    "unusualprehistory:anuro_flask",
+    "unusualprehistory:beelz_flask",
+    "unusualprehistory:coty_flask",
+    "unusualprehistory:dunk_flask",
+    "unusualprehistory:majunga_flask",
+    "unusualprehistory:stetha_flask"
+  ]
+}


### PR DESCRIPTION
Analyzer now consumes flasks only for items in the `filled_flasks` item tag.
Analyzer does not run when all output slots are occupied.
Cultivator now stores empty flask.
Cultivator now consumes fuel.
Added cultivator recipe type.