### PR TITLE
Compatibility for analyzer and cultivator with hoppers

### DIFF
--- a/src/main/java/com/peeko32213/unusualprehistory/common/block/entity/AnalyzerBlockEntity.java
+++ b/src/main/java/com/peeko32213/unusualprehistory/common/block/entity/AnalyzerBlockEntity.java
@@ -45,9 +45,7 @@ public class AnalyzerBlockEntity extends BlockEntity implements MenuProvider {
 
     // Add new flasks to the item tag
     private static final TagKey<Item> FILLED_FLASKS = ForgeRegistries.ITEMS.tags().createTagKey(new ResourceLocation(UnusualPrehistory.MODID, "filled_flasks"));
-    private static final int[] SLOTS_FOR_UP = new int[]{0};
-    private static final int[] SLOTS_FOR_DOWN = new int[]{2, 3, 4, 5,6,7};
-    private static final int[] SLOTS_FOR_SIDES = new int[]{1};
+
     public AnalyzerBlockEntity(BlockPos pWorldPosition, BlockState pBlockState) {
         super(UPBlockEntities.ANALYZER_BLOCK_ENTITY.get(), pWorldPosition, pBlockState);
         this.data = new ContainerData() {

--- a/src/main/java/com/peeko32213/unusualprehistory/common/block/entity/AnalyzerBlockEntity.java
+++ b/src/main/java/com/peeko32213/unusualprehistory/common/block/entity/AnalyzerBlockEntity.java
@@ -5,6 +5,7 @@ import com.peeko32213.unusualprehistory.common.recipe.AnalyzerRecipe;
 import com.peeko32213.unusualprehistory.common.screen.AnalyzerMenu;
 import com.peeko32213.unusualprehistory.core.registry.UPBlockEntities;
 import com.peeko32213.unusualprehistory.core.registry.UPItems;
+import com.peeko32213.unusualprehistory.core.registry.UPTags;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
@@ -22,6 +23,7 @@ import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ContainerData;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -35,6 +37,7 @@ import net.minecraftforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.Random;
 
@@ -42,7 +45,9 @@ public class AnalyzerBlockEntity extends BlockEntity implements MenuProvider {
 
     // Add new flasks to the item tag
     private static final TagKey<Item> FILLED_FLASKS = ForgeRegistries.ITEMS.tags().createTagKey(new ResourceLocation(UnusualPrehistory.MODID, "filled_flasks"));
-
+    private static final int[] SLOTS_FOR_UP = new int[]{0};
+    private static final int[] SLOTS_FOR_DOWN = new int[]{2, 3, 4, 5,6,7};
+    private static final int[] SLOTS_FOR_SIDES = new int[]{1};
     public AnalyzerBlockEntity(BlockPos pWorldPosition, BlockState pBlockState) {
         super(UPBlockEntities.ANALYZER_BLOCK_ENTITY.get(), pWorldPosition, pBlockState);
         this.data = new ContainerData() {
@@ -72,10 +77,67 @@ public class AnalyzerBlockEntity extends BlockEntity implements MenuProvider {
         protected void onContentsChanged(int slot) {
             setChanged();
         }
+
+
+
+        @Override
+        public int getSlotLimit(int slot) {
+            return 64;
+        }
     };
 
+    private IItemHandler hopperHandler = new IItemHandler() {
+        @Override
+        public int getSlots() {
+            return itemHandler.getSlots();
+        }
 
-    private LazyOptional<IItemHandler> lazyItemHandler = LazyOptional.empty();
+        @NotNull
+        @Override
+        public ItemStack getStackInSlot(int slot) {
+            return itemHandler.getStackInSlot(slot);
+        }
+
+        @NotNull
+        @Override
+        public ItemStack extractItem(int slot, int amount, boolean simulate) {
+
+
+            if(slot != 0 && slot != 1){
+                return itemHandler.extractItem(slot, amount, simulate);
+            }
+            return ItemStack.EMPTY;
+        }
+
+        @NotNull
+        @Override
+        public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
+            if(stack.isEmpty()){
+                return stack;
+            }
+
+            if(slot == 0 && stack.is(UPItems.FLASK.get())){
+                return itemHandler.insertItem(slot, stack, simulate);
+            }
+            if(slot == 1 && stack.is(UPTags.ANALYZER_ITEMS_INPUT)) {
+                return itemHandler.insertItem(slot, stack, simulate);
+            }
+            return stack;
+        }
+
+        @Override
+        public int getSlotLimit(int slot) {
+            return itemHandler.getSlotLimit(slot);
+        }
+
+        @Override
+        public boolean isItemValid(int slot, @NotNull ItemStack stack) {
+            return itemHandler.isItemValid(slot, stack);
+        }
+    };
+
+    private LazyOptional<IItemHandler> lazyItemHandlerOptional = LazyOptional.of(() -> itemHandler);
+    private LazyOptional<IItemHandler> hopperHandlerOptional = LazyOptional.of(() -> hopperHandler);
 
     protected final ContainerData data;
     private int progress = 0;
@@ -90,7 +152,12 @@ public class AnalyzerBlockEntity extends BlockEntity implements MenuProvider {
     @Override
     public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> cap, @javax.annotation.Nullable Direction side) {
         if (cap == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
-            return lazyItemHandler.cast();
+            if (side == null) {
+                return lazyItemHandlerOptional.cast();
+            } else{
+                return hopperHandlerOptional.cast();
+            }
+
         }
 
         return super.getCapability(cap, side);
@@ -99,13 +166,15 @@ public class AnalyzerBlockEntity extends BlockEntity implements MenuProvider {
     @Override
     public void onLoad() {
         super.onLoad();
-        lazyItemHandler = LazyOptional.of(() -> itemHandler);
+        lazyItemHandlerOptional = LazyOptional.of(() -> itemHandler);
+        hopperHandlerOptional = LazyOptional.of(() -> hopperHandler);
     }
 
     @Override
     public void invalidateCaps()  {
         super.invalidateCaps();
-        lazyItemHandler.invalidate();
+        lazyItemHandlerOptional.invalidate();
+        hopperHandlerOptional.invalidate();
     }
 
     @Override
@@ -216,6 +285,16 @@ public class AnalyzerBlockEntity extends BlockEntity implements MenuProvider {
     @Override
     public AbstractContainerMenu createMenu(int pContainerId, Inventory pInventory, Player pPlayer) {
         return new AnalyzerMenu(pContainerId, pInventory, this, this.data);
+    }
+
+    public boolean canPlaceItem(int pIndex, ItemStack pStack) {
+        if (pIndex == 0) {
+            return pStack.is(UPItems.FLASK.get());
+        } else if (pIndex == 1) {
+            return pStack.is(UPTags.ALLOWED_FRIDGE_ITEMS);
+        } else {
+            return false;
+        }
     }
 
 

--- a/src/main/java/com/peeko32213/unusualprehistory/core/registry/UPTags.java
+++ b/src/main/java/com/peeko32213/unusualprehistory/core/registry/UPTags.java
@@ -19,7 +19,8 @@ public class UPTags {
     public static final TagKey<EntityType<?>> RAPTOR_TARGETS = registerEntityTag("raptor_targets");
     public static final TagKey<EntityType<?>> ENCRUSTED_TARGETS = registerEntityTag("encrusted_targets");
     public static final TagKey<Item> ALLOWED_FRIDGE_ITEMS = registerItemTag("allowed_fridge_items");
-    
+    public static final TagKey<Item> ANALYZER_ITEMS_INPUT = registerItemTag("analyzer_items");
+    public static final TagKey<Item> DNA_FLASKS = registerItemTag("filled_flasks");
     public static final TagKey<Block> TRIKE_BREAKABLES = registerBlockTag("trike_breakables");
     public static final TagKey<Block> PASSIVE_BRACHI_BREAKABLES = registerBlockTag("passive_brachi_breakables");
     public static final TagKey<Block> ANGRY_BRACHI_BREAKABLES = registerBlockTag("angry_brachi_breakables");

--- a/src/main/resources/data/unusualprehistory/tags/items/analyzer_items.json
+++ b/src/main/resources/data/unusualprehistory/tags/items/analyzer_items.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "unusualprehistory:amber_fossil",
+    "unusualprehistory:plant_fossil_item",
+    "unusualprehistory:paleo_fossil",
+    "unusualprehistory:mezo_fossil"
+  ]
+}


### PR DESCRIPTION
This should add compatibility for the analyzer and cultivator with hoppers. It will only extract resulting items and you can add items to a tag in order to allow more items to be inserted 